### PR TITLE
Optimize S05tp and hyn touch driver

### DIFF
--- a/buildroot/board/cvitek/SG200X/overlay/etc/init.d/S05tp
+++ b/buildroot/board/cvitek/SG200X/overlay/etc/init.d/S05tp
@@ -8,7 +8,8 @@ then
 	then
 		echo "load cst7xx touchscreen driver"
 		insmod /mnt/system/ko/hynitron_touch_new.ko
-	else
+	elif [ "$panel_value" = "st7701_hd228001c31" ]
+	then
 		echo "load cst3xx touchscreen driver"
 		insmod /mnt/system/ko/hynitron_touch.ko
 	fi

--- a/linux_5.10/drivers/input/touchscreen/hyn/hyn_core.c
+++ b/linux_5.10/drivers/input/touchscreen/hyn/hyn_core.c
@@ -283,7 +283,7 @@ static void touch_updata(u8 idx,u8 event)
         input_mt_report_slot_state(dev, MT_TOOL_FINGER, 1);
         input_report_abs(dev, ABS_MT_TRACKING_ID, rep_frame->pos_info[idx].pos_id);
         input_report_abs(dev, ABS_MT_POSITION_X, rep_frame->pos_info[idx].pos_x);
-        input_report_abs(dev, ABS_MT_POSITION_Y, rep_frame->pos_info[idx].pos_y+25);
+        input_report_abs(dev, ABS_MT_POSITION_Y, rep_frame->pos_info[idx].pos_y);
         input_report_abs(dev, ABS_MT_TOUCH_MAJOR, zpress>>3);
         input_report_abs(dev, ABS_MT_WIDTH_MAJOR, zpress>>3);
         input_report_abs(dev, ABS_MT_PRESSURE, zpress);


### PR DESCRIPTION
- Optimize S05tp.
- Optimize hyn touch driver because the screen has been calibrated.