### PR TITLE
fix lct024bsi20 mipi porch

### DIFF
--- a/middleware/v2/sample/scene_auto/Makefile
+++ b/middleware/v2/sample/scene_auto/Makefile
@@ -34,7 +34,7 @@ LIBS += -lnanomsg
 endif
 
 EXTRA_CFLAGS = $(INCS) $(DEFS)
-EXTRA_LDFLAGS = $(LIBS) -lpthread -lm -lini
+EXTRA_LDFLAGS = $(LIBS) -lpthread -lm -lini -latomic
 
 .PHONY : clean all
 all: $(TARGET)

--- a/u-boot-2021.10/include/cvitek/cvi_panels/dsi_d240si31.h
+++ b/u-boot-2021.10/include/cvitek/cvi_panels/dsi_d240si31.h
@@ -22,13 +22,13 @@
 
 #define D240SI31_VACT		640
 #define D240SI31_VSA		10
-#define D240SI31_VBP		12
-#define D240SI31_VFP		3
+#define D240SI31_VBP		30
+#define D240SI31_VFP		30
 
 #define D240SI31_HACT		480
 #define D240SI31_HSA		48
-#define D240SI31_HBP		64
-#define D240SI31_HFP		16
+#define D240SI31_HBP		30
+#define D240SI31_HFP		30
 
 #define DXQ_PIXEL_CLK(x) ((x##_VACT + x##_VSA + x##_VBP + x##_VFP) \
 	* (x##_HACT + x##_HSA + x##_HBP + x##_HFP) * 60 / 1000)


### PR DESCRIPTION
1. fix lct024bsi20 mipi porch
2. add -latomic to linker flags for scene_auto sample to fix archlinux build error