### PR TITLE
i2c: fix stack buffer overflow vulnerability in i2c md command

### DIFF
--- a/u-boot-2021.10/cmd/i2c.c
+++ b/u-boot-2021.10/cmd/i2c.c
@@ -248,10 +248,10 @@ int i2c_set_bus_speed(unsigned int speed)
  *
  * Returns the address length.
  */
-static uint get_alen(char *arg, int default_len)
+static uint get_alen(char *arg, uint default_len)
 {
-	int	j;
-	int	alen;
+	uint	j;
+	uint	alen;
 
 	alen = default_len;
 	for (j = 0; j < 8; j++) {
@@ -295,7 +295,7 @@ static int do_i2c_read(struct cmd_tbl *cmdtp, int flag, int argc,
 {
 	uint	chip;
 	uint	devaddr, length;
-	int alen;
+	uint	alen;
 	u_char  *memaddr;
 	int ret;
 #if CONFIG_IS_ENABLED(DM_I2C)
@@ -349,7 +349,7 @@ static int do_i2c_write(struct cmd_tbl *cmdtp, int flag, int argc,
 {
 	uint	chip;
 	uint	devaddr, length;
-	int alen;
+	uint	alen;
 	u_char  *memaddr;
 	int ret;
 #if CONFIG_IS_ENABLED(DM_I2C)
@@ -517,8 +517,8 @@ static int do_i2c_md(struct cmd_tbl *cmdtp, int flag, int argc,
 {
 	uint	chip;
 	uint	addr, length;
-	int alen;
-	int	j, nbytes, linebytes;
+	uint	alen;
+	uint	j, nbytes, linebytes;
 	int ret;
 #if CONFIG_IS_ENABLED(DM_I2C)
 	struct udevice *dev;
@@ -637,9 +637,9 @@ static int do_i2c_mw(struct cmd_tbl *cmdtp, int flag, int argc,
 {
 	uint	chip;
 	ulong	addr;
-	int	alen;
+	uint	alen;
 	uchar	byte;
-	int	count;
+	uint	count;
 	int ret;
 #if CONFIG_IS_ENABLED(DM_I2C)
 	struct udevice *dev;
@@ -724,8 +724,8 @@ static int do_i2c_crc(struct cmd_tbl *cmdtp, int flag, int argc,
 {
 	uint	chip;
 	ulong	addr;
-	int	alen;
-	int	count;
+	uint	alen;
+	uint	count;
 	uchar	byte;
 	ulong	crc;
 	ulong	err;
@@ -1033,7 +1033,7 @@ static int do_i2c_loop(struct cmd_tbl *cmdtp, int flag, int argc,
 		       char *const argv[])
 {
 	uint	chip;
-	int alen;
+	uint	alen;
 	uint	addr;
 	uint	length;
 	u_char	bytes[16];


### PR DESCRIPTION
This PR fixes a potential security vulnerability in u-boot-2021.10/cmd/i2c.c that was cloned from https://github.com/u-boot/u-boot but did not receive the security patch.

### Details:
Affected Function: get_alen, do_i2c_read, do_i2c_write, do_i2c_md, do_i2c_mw, do_i2c_crc, do_i2c_loop in u-boot-2021.10/cmd/i2c.c
Original Fix: https://github.com/u-boot/u-boot/commit/8f8c04bf1ebbd2f72f1643e7ad9617dafa6e5409

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/u-boot/u-boot/commit/8f8c04bf1ebbd2f72f1643e7ad9617dafa6e5409
- https://nvd.nist.gov/vuln/detail/CVE-2022-34835

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
