### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/u-boot-2021.10/lib/bzip2/bzlib_decompress.c
+++ b/u-boot-2021.10/lib/bzip2/bzlib_decompress.c
@@ -330,7 +330,7 @@ Int32 BZ2_decompress ( DState* s )
       GET_BITS(BZ_X_SELECTOR_1, nGroups, 3);
       if (nGroups < 2 || nGroups > 6) RETURN(BZ_DATA_ERROR);
       GET_BITS(BZ_X_SELECTOR_2, nSelectors, 15);
-      if (nSelectors < 1) RETURN(BZ_DATA_ERROR);
+      if (nSelectors < 1 || nSelectors > BZ_MAX_SELECTORS) RETURN(BZ_DATA_ERROR);
       for (i = 0; i < nSelectors; i++) {
 	 j = 0;
 	 while (True) {


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in u-boot-2021.10/lib/bzip2/bzlib_decompress.c which was cloned from federicomenaquintero/bzip2 but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2019-12900.

### Proposed Fix
Apply the same patch as the one in federicomenaquintero/bzip2 to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2019-12900
https://gitlab.com/federicomenaquintero/bzip2/-/commit/74de1e2e6ffc9d51ef9824db71a8ffee5962cdbc