### PR TITLE
Add sensor configuration file for LONTIUM_LT6911

### DIFF
--- a/buildroot/board/cvitek/SG200X/overlay/mnt/data/sensor_cfg.ini.LT
+++ b/buildroot/board/cvitek/SG200X/overlay/mnt/data/sensor_cfg.ini.LT
@@ -1,0 +1,34 @@
+[source]
+
+;type = SOURCE_USER_FE
+
+dev_num = 1
+
+; section for sensor
+
+[sensor]
+
+; sensor name
+name = LONTIUM_LT6911_2M_60FPS_8BIT
+
+bus_id = 4
+
+sns_i2c_addr = ff
+
+mipi_dev = 0
+
+lane_id = 2, 4, 3, 1, 0
+
+pn_swap = 0, 0, 0, 0, 0
+
+mclk_en = 0
+
+mclk = 0
+
+;port = 0
+
+;pin = 2
+
+;pol = 1
+
+fps = 60


### PR DESCRIPTION
Im pretty sure there was a missing sensor configuration. When trying to build by myself, the NanoKVM Server kept segfaulting. Adding the configuration file for the LONTIUM_LT6911 fixed it